### PR TITLE
Fix bug in handling plists with comments

### DIFF
--- a/lib/rbXMLCFPropertyList.rb
+++ b/lib/rbXMLCFPropertyList.rb
@@ -72,6 +72,7 @@ module CFPropertyList
         if node.children? then
           node.children.each do |n|
             next if n.text? # avoid a bug of libxml
+            next if n.comment?
 
             if n.name == "key" then
               key = get_value(n)


### PR DESCRIPTION
When CFPropertyList encountered a plist with a comment ( <!--Uncomment
these keys to enable malloc debugging-->), it would raise a
CFFormatError.  To fix this, we skip the XML child if it contains a
comment by using LIBXML's .comment? method.
