### PR TITLE
Issue when reading XML pists using the :file parameter

### DIFF
--- a/lib/rbNokogiriParser.rb
+++ b/lib/rbNokogiriParser.rb
@@ -10,6 +10,8 @@ module CFPropertyList
     # * :file - The filename of the file to load
     # * :data - The data to parse
     def load(opts)
+
+      doc = nil
       if(opts.has_key?(:file)) then
         File.open(opts[:file], "rb") { |fd| doc = Nokogiri::XML::Document.parse(fd, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS|Nokogiri::XML::ParseOptions::NOENT) }
       else

--- a/lib/rbREXMLParser.rb
+++ b/lib/rbREXMLParser.rb
@@ -10,6 +10,8 @@ module CFPropertyList
     # * :file - The filename of the file to load
     # * :data - The data to parse
     def load(opts)
+
+      doc = nil
       if(opts.has_key?(:file)) then
         File.open(opts[:file], "rb") { |fd| doc = REXML::Document.new(fd) }
       else


### PR DESCRIPTION
When attempting to read an XML based property list using the :file parameter, it was choking because the doc variable was going out of scope after it was created in the block. It now is defined right before the conditional and now continues to persist after the conditional is executed.

Ryan
