### PR TITLE
Raise IOError when reading a blank file

### DIFF
--- a/lib/rbCFPropertyList.rb
+++ b/lib/rbCFPropertyList.rb
@@ -296,7 +296,7 @@ module CFPropertyList
 
         prsr = nil
         if filetype == "bplist" then
-          raise CFFormatError.new("Wong file version #{version}") unless version == "00"
+          raise CFFormatError.new("Wrong file version #{version}") unless version == "00"
           prsr = Binary.new
         else
           prsr = CFPropertyList.xml_parser_interface.new


### PR DESCRIPTION
Previously, a blank file passed to CFPropertyList::List.new() would raise
a NoMethodError on the magic_number variable as it would try to address a
range of characters with [].

This commit will raise an IOError in the event that magic_number is not
populated, and present a better message than a NoMethodError.
