### PR TITLE
24-bit offset table unpack specifier does not work on Ruby 1.8.7

### DIFF
--- a/lib/rbBinaryCFPropertyList.rb
+++ b/lib/rbBinaryCFPropertyList.rb
@@ -38,10 +38,13 @@ module CFPropertyList
       @count_objects = number_of_objects
 
       # decode offset table
-      formats = ["","C*","n*","(H6)*","N*"]
-      @offsets = coded_offset_table.unpack(formats[offset_size])
-      if(offset_size == 3)
-        0.upto(@offsets.size-1) { |i| @offsets[i] = @offsets[i].to_i(16) }
+      if(offset_size != 3)
+        formats = ["","C*","n*","","N*"]
+        @offsets = coded_offset_table.unpack(formats[offset_size])
+      else
+        @offsets = coded_offset_table.unpack("C*").each_slice(3).map {
+          |x,y,z| (x << 16) | (y << 8) | z
+        }
       end
 
       @object_ref_size = object_ref_size


### PR DESCRIPTION
CFPropertyList::Binary.load will attempt to decode an offset table of 24-bit entries by first unpacking a big-endian hex string for every 3 bytes, and then parsing the hex string to an integer.

However, on ruby 1.8.7, the unpack specifier "(H6)_" does not appear to work as intended. The result is that only one entry from the offset table is correctly unpacked. The Ruby documentation does not seem to permit parentheses in the specifier ("H6_" doesn't work either).
