### PR TITLE
retain detected format in auto mode

### DIFF
--- a/lib/rbCFPropertyList.rb
+++ b/lib/rbCFPropertyList.rb
@@ -288,8 +288,10 @@ module CFPropertyList
         if filetype == "bplist" then
           raise CFFormatError.new("Wrong file version #{version}") unless version == "00"
           prsr = Binary.new
+          @format = List::FORMAT_BINARY
         else
           prsr = CFPropertyList.xml_parser_interface.new
+          @format = List::FORMAT_XML
         end
 
         @value = prsr.load({:data => str})
@@ -321,8 +323,10 @@ module CFPropertyList
         if filetype == "bplist" then
           raise CFFormatError.new("Wong file version #{version}") unless version == "00"
           prsr = Binary.new
+          @format = List::FORMAT_BINARY
         else
           prsr = CFPropertyList.xml_parser_interface.new
+          @format = List::FORMAT_XML
         end
 
         @value = prsr.load({:file => file})


### PR DESCRIPTION
I need to parse a plist blob, tweak it, and reserialize it, in whatever format it came in. This tweak simply remembers the format that the auto detector detected.
