### PR TITLE
Ignore text and comments inside arrays; just like inside dictionaries

### DIFF
--- a/lib/rbLibXMLParser.rb
+++ b/lib/rbLibXMLParser.rb
@@ -105,6 +105,8 @@ module CFPropertyList
 
         if node.children? then
           node.children.each do |n|
+            next if n.text? # avoid a bug of libxml
+            next if n.comment?
             ary.push import_xml(n)
           end
         end

--- a/lib/rbNokogiriParser.rb
+++ b/lib/rbNokogiriParser.rb
@@ -112,6 +112,8 @@ module CFPropertyList
 
         unless children.empty? then
           children.each do |n|
+            next if n.text? # avoid a bug of libxml
+            next if n.comment?
             ary.push import_xml(n)
           end
         end

--- a/lib/rbREXMLParser.rb
+++ b/lib/rbREXMLParser.rb
@@ -108,6 +108,7 @@ module CFPropertyList
 
         if node.has_elements? then
           node.elements.each do |n|
+            next if n.name == '#text' # avoid a bug of libxml
             ary.push import_xml(n)
           end
         end

--- a/test/reference/array2.xml
+++ b/test/reference/array2.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><array>
+</array></plist>

--- a/test/reference/array3.xml
+++ b/test/reference/array3.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><array>
+<!-- test -->
+</array></plist>

--- a/test/test_array2.rb
+++ b/test/test_array2.rb
@@ -1,0 +1,16 @@
+require 'test/unit'
+
+require 'rubygems'
+#gem 'libxml-ruby'
+
+require 'cfpropertylist'
+require 'reference'
+
+class TestArray < Test::Unit::TestCase
+  include Reference
+
+  def test_read_array
+    assert_equal [ ], parsed_xml('array2')
+  end
+
+end

--- a/test/test_array3.rb
+++ b/test/test_array3.rb
@@ -1,0 +1,16 @@
+require 'test/unit'
+
+require 'rubygems'
+#gem 'libxml-ruby'
+
+require 'cfpropertylist'
+require 'reference'
+
+class TestArray < Test::Unit::TestCase
+  include Reference
+
+  def test_read_array
+    assert_equal [ ], parsed_xml('array3')
+  end
+
+end


### PR DESCRIPTION
Tester noticed that whitespace inside <array> </array> was generating [nil] instead of []
Dictionaries already prune text and comments so this makes arrays do the same.
