### PR TITLE
Fix for native_types returning Blob data

### DIFF
--- a/lib/rbCFPropertyList.rb
+++ b/lib/rbCFPropertyList.rb
@@ -186,7 +186,7 @@ module CFPropertyList
     if(object.is_a?(CFDate) || object.is_a?(CFString) || object.is_a?(CFInteger) || object.is_a?(CFReal) || object.is_a?(CFBoolean)) then
       return object.value
     elsif(object.is_a?(CFData)) then
-      return object.decoded_value
+      return CFPropertyList::Blob.new(object.decoded_value)
     elsif(object.is_a?(CFArray)) then
       ary = []
       object.value.each do


### PR DESCRIPTION
Previously, native_types would return an object's `decoded_value` if
it was determined that the object was a CFData type.
Because the decoded_value was a String, the native type returned
would contain String data instead of CFPropertyList::Blob data. This caused
a problem when you tried to convert that native type to a plist - the underlying
parser would raise an Encoding error whenever it tried to handle binary data
that was in a String format instead of a CFData format.

This commit returns the `decoded_value` wrapped in a CFPropertyList::Blob
declaration, which will return a native type containing an item of
CFPropertyList::Blob, instead of type String, which CFPropertyList correctly
handles when you try to convert it to a plist.
