### PR TITLE
Decode unicode strings in plain plists

### DIFF
--- a/lib/cfpropertylist/rbPlainCFPropertyList.rb
+++ b/lib/cfpropertylist/rbPlainCFPropertyList.rb
@@ -123,6 +123,8 @@ module CFPropertyList
         "\r"
       when 't'
         "\t"
+      when 'U'
+        @doc.scan(/.{4}/).hex.chr('utf-8')
       end
     end
 


### PR DESCRIPTION
Unicode character sometimes are represented as codepoints (often at logging, at least) and right now parsing of such strings are broken:
```
> CFPropertyList::List.new.load_str('"\U041a\U043e\U043d\U0441\U0442\U0430\U043d\U0442\U0438\U043d"')
TypeError: no implicit conversion of nil into String
	from /home/ojab/.rvm/gems/ruby-2.2.1@tst/gems/CFPropertyList-2.3.1/lib/cfpropertylist/rbPlainCFPropertyList.rb:135:in `read_quoted'
	from /home/ojab/.rvm/gems/ruby-2.2.1@tst/gems/CFPropertyList-2.3.1/lib/cfpropertylist/rbPlainCFPropertyList.rb:185:in `import_plain'
	from /home/ojab/.rvm/gems/ruby-2.2.1@tst/gems/CFPropertyList-2.3.1/lib/cfpropertylist/rbPlainCFPropertyList.rb:24:in `load'
	from /home/ojab/.rvm/gems/ruby-2.2.1@tst/gems/CFPropertyList-2.3.1/lib/cfpropertylist/rbCFPropertyList.rb:335:in `load_str'
	from (irb):2
	from /home/ojab/.rvm/rubies/ruby-2.2.1/bin/irb:11:in `<main>'
```
with this patch the string is properly decoded:
```
> CFPropertyList::List.new.load_str('"\U041a\U043e\U043d\U0441\U0442\U0430\U043d\U0442\U0438\U043d"')
=> #<CFPropertyList::CFString:0x007ffbcca232b0 @value="Константин">
```