### PR TITLE
Derive CFPlistError from StandardError instead of Exception

### DIFF
--- a/lib/cfpropertylist/rbCFPlistError.rb
+++ b/lib/cfpropertylist/rbCFPlistError.rb
@@ -12,7 +12,7 @@
 # License::   MIT License
 
 # general plist error. All exceptions thrown are derived from this class.
-class CFPlistError < Exception
+class CFPlistError < StandardError
 end
 
 # Exception thrown when format errors occur


### PR DESCRIPTION
This allows us to use rescue without specifying exception class.

Right now it isn't possible to use something like
```ruby
begin
  do_work
rescue
  binding.pry
end
```
for debugging if there is calls to CFPropertyList in do_work, because it catches StandardError, not Exception.