### PR TITLE
Set width for rexml pretty formatter to large number

### DIFF
--- a/lib/cfpropertylist/rbREXMLParser.rb
+++ b/lib/cfpropertylist/rbREXMLParser.rb
@@ -40,6 +40,7 @@ module CFPropertyList
       formatter = if opts[:formatted] then
         f = REXML::Formatters::Pretty.new(2)
         f.compact = true
+        f.width = 99999
         f
       else
         REXML::Formatters::Default.new


### PR DESCRIPTION
This stops the formatted XML from changing the contents of the string itself.