### PR TITLE
Include NONET flag for security

### DIFF
--- a/lib/cfpropertylist/rbLibXMLParser.rb
+++ b/lib/cfpropertylist/rbLibXMLParser.rb
@@ -5,6 +5,7 @@ require 'libxml'
 module CFPropertyList
   # XML parser
   class LibXMLParser < XMLParserInterface
+    PARSER_OPTIONS = LibXML::XML::Parser::Options::NOBLANKS|LibXML::XML::Parser::Options::NOENT|LibXML::XML::Parser::Options::NONET
     # read a XML file
     # opts::
     # * :file - The filename of the file to load
@@ -13,9 +14,9 @@ module CFPropertyList
       doc = nil
 
       if(opts.has_key?(:file)) then
-        doc = LibXML::XML::Document.file(opts[:file],:options => LibXML::XML::Parser::Options::NOBLANKS|LibXML::XML::Parser::Options::NOENT)
+        doc = LibXML::XML::Document.file(opts[:file],:options => PARSER_OPTIONS)
       else
-        doc = LibXML::XML::Document.string(opts[:data],:options => LibXML::XML::Parser::Options::NOBLANKS|LibXML::XML::Parser::Options::NOENT)
+        doc = LibXML::XML::Document.string(opts[:data],:options => PARSER_OPTIONS)
       end
 
       if doc

--- a/lib/cfpropertylist/rbNokogiriParser.rb
+++ b/lib/cfpropertylist/rbNokogiriParser.rb
@@ -5,6 +5,7 @@ require 'nokogiri'
 module CFPropertyList
   # XML parser
   class NokogiriXMLParser < ParserInterface
+    PARSER_OPTIONS = Nokogiri::XML::ParseOptions::NOBLANKS|Nokogiri::XML::ParseOptions::NOENT|Nokogiri::XML::ParseOptions::NONET
     # read a XML file
     # opts::
     # * :file - The filename of the file to load
@@ -12,9 +13,9 @@ module CFPropertyList
     def load(opts)
       doc = nil
       if(opts.has_key?(:file)) then
-        File.open(opts[:file], "rb") { |fd| doc = Nokogiri::XML::Document.parse(fd, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS|Nokogiri::XML::ParseOptions::NOENT) }
+        File.open(opts[:file], "rb") { |fd| doc = Nokogiri::XML::Document.parse(fd, nil, nil, PARSER_OPTIONS) }
       else
-        doc = Nokogiri::XML::Document.parse(opts[:data], nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS|Nokogiri::XML::ParseOptions::NOENT)
+        doc = Nokogiri::XML::Document.parse(opts[:data], nil, nil, PARSER_OPTIONS)
       end
 
       if doc


### PR DESCRIPTION
Currently, CFPropertyList processes external URL entities in plists. This can lead to third party attacks: a PLIST is provided that references an external URL, causing CFPropertyList to contact the host of the URL to download its contents and include it in the XML. 

This merge request extends the spirit of the `NOENT` parser option by adding `NONET` as well.

More information about this type of vulnerability is available at https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing