### PR TITLE
remove NOENT option for security

### DIFF
--- a/lib/cfpropertylist/rbLibXMLParser.rb
+++ b/lib/cfpropertylist/rbLibXMLParser.rb
@@ -5,7 +5,7 @@ require 'libxml'
 module CFPropertyList
   # XML parser
   class LibXMLParser < XMLParserInterface
-    PARSER_OPTIONS = LibXML::XML::Parser::Options::NOBLANKS|LibXML::XML::Parser::Options::NOENT|LibXML::XML::Parser::Options::NONET
+    PARSER_OPTIONS = LibXML::XML::Parser::Options::NOBLANKS|LibXML::XML::Parser::Options::NONET
     # read a XML file
     # opts::
     # * :file - The filename of the file to load

--- a/lib/cfpropertylist/rbNokogiriParser.rb
+++ b/lib/cfpropertylist/rbNokogiriParser.rb
@@ -5,7 +5,7 @@ require 'nokogiri'
 module CFPropertyList
   # XML parser
   class NokogiriXMLParser < ParserInterface
-    PARSER_OPTIONS = Nokogiri::XML::ParseOptions::NOBLANKS|Nokogiri::XML::ParseOptions::NOENT|Nokogiri::XML::ParseOptions::NONET
+    PARSER_OPTIONS = Nokogiri::XML::ParseOptions::NOBLANKS|Nokogiri::XML::ParseOptions::NONET
     # read a XML file
     # opts::
     # * :file - The filename of the file to load


### PR DESCRIPTION
NOENT, which is used to substitute entities also enables processing of
both regular and external entities. Which seems risky when you don't
trust the XML source. NONET will have no effect if used with NOENT.

- Github Issue: https://github.com/ckruse/CFPropertyList/issues/55