### PR TITLE
Specify dependencies in gemspec, add GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: Main
+on: [push, pull_request]
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
+        ruby: [2.7, '3.0', head]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - run: bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source "https://rubygems.org"
+gemspec

--- a/cfpropertylist.gemspec
+++ b/cfpropertylist.gemspec
@@ -14,5 +14,9 @@ Gem::Specification.new do |s|
   #s.test_files = FileList["{test}/**/*test.rb"].to_a
   s.has_rdoc = true
   s.extra_rdoc_files = ["README.rdoc"]
+  s.add_runtime_dependency("libxml-ruby")
+  s.add_runtime_dependency("nokogiri")
+  s.add_runtime_dependency("rexml") # required after ruby 3
+  s.add_development_dependency("minitest")
   s.add_development_dependency("rake",">=0.7.0")
 end

--- a/cfpropertylist.gemspec
+++ b/cfpropertylist.gemspec
@@ -14,9 +14,11 @@ Gem::Specification.new do |s|
   #s.test_files = FileList["{test}/**/*test.rb"].to_a
   s.has_rdoc = true
   s.extra_rdoc_files = ["README.rdoc"]
-  s.add_runtime_dependency("libxml-ruby")
-  s.add_runtime_dependency("nokogiri")
-  s.add_runtime_dependency("rexml") # required after ruby 3
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
+    s.add_runtime_dependency("rexml") # no longer bundled with Ruby 3
+  end
+  s.add_development_dependency("libxml-ruby")
   s.add_development_dependency("minitest")
+  s.add_development_dependency("nokogiri")
   s.add_development_dependency("rake",">=0.7.0")
 end


### PR DESCRIPTION
Ruby 3 promoted `rexml` to a bundled gem:

https://www.ruby-lang.org/en/news/2020/09/25/ruby-3-0-0-preview1-released/

Downstream users with Ruby 3 need to specify `gem "rexml"` when using this project, this actually affects many `CocoaPods` users:

- https://github.com/CocoaPods/CocoaPods/issues/10388
- https://github.com/CocoaPods/CocoaPods/issues/10686

By specifying dependencies in our `gemspec`, we eliminate the need for them to do so.

Also Github Actions is added as CI.