### PR TITLE
Suppress `libxml-ruby` warnings and errors from printing to `STDERR`

### DIFF
--- a/lib/cfpropertylist/rbLibXMLParser.rb
+++ b/lib/cfpropertylist/rbLibXMLParser.rb
@@ -5,6 +5,7 @@ require 'libxml'
 module CFPropertyList
   # XML parser
   class LibXMLParser < XMLParserInterface
+    LibXML::XML::Error.set_handler(&LibXML::XML::Error::QUIET_HANDLER)
     PARSER_OPTIONS = LibXML::XML::Parser::Options::NOBLANKS|LibXML::XML::Parser::Options::NONET
     # read a XML file
     # opts::


### PR DESCRIPTION
Parse errors are subsequently handled by catching the raised exception. This
matches how the other parsers (at least `rexml` and `nokogiri`) work - they do
not emit errors to `STDERR` while parsing.

Before:
```
irb(main):002:0> plist = CFPropertyList::List.new(:file => "/Library/LaunchDaemons/com.gopro.GoProWebcamDaemon.plist")
Fatal error: String not started expecting ' or " at /Library/LaunchDaemons/com.gopro.GoProWebcamDaemon.plist:1.
Fatal error: Malformed declaration expecting version at /Library/LaunchDaemons/com.gopro.GoProWebcamDaemon.plist:1.
Fatal error: Blank needed here at /Library/LaunchDaemons/com.gopro.GoProWebcamDaemon.plist:1.
Fatal error: parsing XML declaration: '?>' expected at /Library/LaunchDaemons/com.gopro.GoProWebcamDaemon.plist:1.
Fatal error: SystemLiteral " or ' expected at /Library/LaunchDaemons/com.gopro.GoProWebcamDaemon.plist:2.
Fatal error: PUBLIC, the Public Identifier is missing at /Library/LaunchDaemons/com.gopro.GoProWebcamDaemon.plist:2.
Fatal error: Space required after the Public Identifier at /Library/LaunchDaemons/com.gopro.GoProWebcamDaemon.plist:2.
Fatal error: SystemLiteral " or ' expected at /Library/LaunchDaemons/com.gopro.GoProWebcamDaemon.plist:2.
Fatal error: SYSTEM or PUBLIC, the URI is missing at /Library/LaunchDaemons/com.gopro.GoProWebcamDaemon.plist:2.
Fatal error: DOCTYPE improperly terminated at /Library/LaunchDaemons/com.gopro.GoProWebcamDaemon.plist:2.
Fatal error: Start tag expected, '<' not found at /Library/LaunchDaemons/com.gopro.GoProWebcamDaemon.plist:2.
/Users/crc/src/brew/lib/ruby/gems/3.0.0/gems/CFPropertyList-3.0.4/lib/cfpropertylist/rbLibXMLParser.rb:27:in `rescue in load': invalid XML: Fatal error: Start tag expected, '<' not found at /Library/LaunchDaemons/com.gopro.GoProWebcamDaemon.plist:2. (CFFormatError)
  from /Users/crc/src/brew/lib/ruby/gems/3.0.0/gems/CFPropertyList-3.0.4/lib/cfpropertylist/rbLibXMLParser.rb:13:in `load'
  from /Users/crc/src/brew/lib/ruby/gems/3.0.0/gems/CFPropertyList-3.0.4/lib/cfpropertylist/rbCFPropertyList.rb:361:in `load'
  from /Users/crc/src/brew/lib/ruby/gems/3.0.0/gems/CFPropertyList-3.0.4/lib/cfpropertylist/rbCFPropertyList.rb:238:in `initialize'
  from (irb):2:in `new'
  from (irb):2:in `<main>'
  from /Users/crc/src/brew/Cellar/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/irb-1.3.5/exe/irb:11:in `<top (required)>'
  from /Users/crc/src/brew/opt/ruby/bin/irb:23:in `load'
  from /Users/crc/src/brew/opt/ruby/bin/irb:23:in `<main>'
/Users/crc/src/brew/lib/ruby/gems/3.0.0/gems/libxml-ruby-3.2.1/lib/libxml/document.rb:34:in `parse': Fatal error: Start tag expected, '<' not found at /Library/LaunchDaemons/com.gopro.GoProWebcamDaemon.plist:2. (LibXML::XML::Error)
  from /Users/crc/src/brew/lib/ruby/gems/3.0.0/gems/libxml-ruby-3.2.1/lib/libxml/document.rb:34:in `file'
  from /Users/crc/src/brew/lib/ruby/gems/3.0.0/gems/CFPropertyList-3.0.4/lib/cfpropertylist/rbLibXMLParser.rb:17:in `load'
  from /Users/crc/src/brew/lib/ruby/gems/3.0.0/gems/CFPropertyList-3.0.4/lib/cfpropertylist/rbCFPropertyList.rb:361:in `load'
  from /Users/crc/src/brew/lib/ruby/gems/3.0.0/gems/CFPropertyList-3.0.4/lib/cfpropertylist/rbCFPropertyList.rb:238:in `initialize'
  from (irb):2:in `new'
  from (irb):2:in `<main>'
  from /Users/crc/src/brew/Cellar/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/irb-1.3.5/exe/irb:11:in `<top (required)>'
  from /Users/crc/src/brew/opt/ruby/bin/irb:23:in `load'
  from /Users/crc/src/brew/opt/ruby/bin/irb:23:in `<main>'
irb(main):003:0>
```

After:
```
irb(main):003:0> plist = CFPropertyList::List.new(:file => "/Library/LaunchDaemons/com.gopro.GoProWebcamDaemon.plist")
/Library/GoogleCorpSupport/Puppet/lib/ruby/gems/3.0.0/gems/CFPropertyList-3.0.4/lib/cfpropertylist/rbLibXMLParser.rb:28:in `rescue in load': invalid XML: Fatal error: Start tag expected, '<' not found at /Library/LaunchDaemons/com.gopro.GoProWebcamDaemon.plist:2. (CFFormatError)
  from /Library/GoogleCorpSupport/Puppet/lib/ruby/gems/3.0.0/gems/CFPropertyList-3.0.4/lib/cfpropertylist/rbLibXMLParser.rb:14:in `load'
  from /Library/GoogleCorpSupport/Puppet/lib/ruby/gems/3.0.0/gems/CFPropertyList-3.0.4/lib/cfpropertylist/rbCFPropertyList.rb:361:in `load'
  from /Library/GoogleCorpSupport/Puppet/lib/ruby/gems/3.0.0/gems/CFPropertyList-3.0.4/lib/cfpropertylist/rbCFPropertyList.rb:238:in `initialize'
  from (irb):3:in `new'
  from (irb):3:in `<main>'
  from /Library/GoogleCorpSupport/Puppet/lib/ruby/gems/3.0.0/gems/irb-1.3.5/exe/irb:11:in `<top (required)>'
  from /Library/GoogleCorpSupport/bin/irb:30:in `load'
  from /Library/GoogleCorpSupport/bin/irb:30:in `<main>'
/Library/GoogleCorpSupport/Puppet/lib/ruby/gems/3.0.0/gems/libxml-ruby-3.2.1/lib/libxml/document.rb:34:in `parse': Fatal error: Start tag expected, '<' not found at /Library/LaunchDaemons/com.gopro.GoProWebcamDaemon.plist:2. (LibXML::XML::Error)
  from /Library/GoogleCorpSupport/Puppet/lib/ruby/gems/3.0.0/gems/libxml-ruby-3.2.1/lib/libxml/document.rb:34:in `file'
  from /Library/GoogleCorpSupport/Puppet/lib/ruby/gems/3.0.0/gems/CFPropertyList-3.0.4/lib/cfpropertylist/rbLibXMLParser.rb:18:in `load'
  from /Library/GoogleCorpSupport/Puppet/lib/ruby/gems/3.0.0/gems/CFPropertyList-3.0.4/lib/cfpropertylist/rbCFPropertyList.rb:361:in `load'
  from /Library/GoogleCorpSupport/Puppet/lib/ruby/gems/3.0.0/gems/CFPropertyList-3.0.4/lib/cfpropertylist/rbCFPropertyList.rb:238:in `initialize'
  from (irb):3:in `new'
  from (irb):3:in `<main>'
  from /Library/GoogleCorpSupport/Puppet/lib/ruby/gems/3.0.0/gems/irb-1.3.5/exe/irb:11:in `<top (required)>'
  from /Library/GoogleCorpSupport/bin/irb:30:in `load'
  from /Library/GoogleCorpSupport/bin/irb:30:in `<main>'
irb(main):004:0>
```