### PR TITLE
Added ruby 3.1 and 3.2 to testing matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,8 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.7, '3.0', head]
+        ruby: [2.7, 3.0, 3.1, 3.2, head]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Hi @ckruse, just a quick change here to add Ruby 3.1 and 3.2 to the testing matrix.