### PR TITLE
Add ruby 3.4 and remove 2.7 from testing matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.7, 3.0, 3.1, 3.2, 3.3, head]
+        ruby: [3.0, 3.1, 3.2, 3.3, 3.4, head]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This pull request:
- **adds**: Ruby 3.4 to testing matrix
- **removes**: Ruby 2.7 from testing matrix