### PR TITLE
fix string escaping in plain format

### DIFF
--- a/lib/cfpropertylist/rbCFTypes.rb
+++ b/lib/cfpropertylist/rbCFTypes.rb
@@ -60,7 +60,7 @@ module CFPropertyList
     end
 
     def to_plain(plist)
-      if @value =~ /^\w+$/
+      if @value =~ /\A\w+\z/
         @value
       else
         quoted
@@ -74,7 +74,7 @@ module CFPropertyList
         when '"'
           '\\"'
         when '\\'
-          '\\'
+          '\\\\'
         when "\a"
           "\\a"
         when "\b"
@@ -82,7 +82,7 @@ module CFPropertyList
         when "\f"
           "\\f"
         when "\n"
-          "\n"
+          "\\n"
         when "\v"
           "\\v"
         when "\r"

--- a/test/test_plain.rb
+++ b/test/test_plain.rb
@@ -114,4 +114,28 @@ class TestPlain < Minitest::Test
     plist.value = CFPropertyList.guess(CFPropertyList::Blob.new("\x00\n"))
     assert_equal raw_plain("binary"), plist.to_str(CFPropertyList::List::FORMAT_PLAIN)
   end
+
+  def test_string_with_backslash_roundtrip
+    original = "foo\\bar"
+    plist = CFPropertyList::List.new
+    plist.value = CFPropertyList.guess(original)
+    plain = plist.to_str(CFPropertyList::List::FORMAT_PLAIN)
+
+    reparsed = CFPropertyList::List.new(:data => plain, :format => CFPropertyList::List::FORMAT_PLAIN)
+    result = CFPropertyList.native_types(reparsed.value)
+
+    assert_equal original, result
+  end
+
+  def test_string_with_newline_roundtrip
+    original = "foo\nbar"
+    plist = CFPropertyList::List.new
+    plist.value = CFPropertyList.guess(original)
+    plain = plist.to_str(CFPropertyList::List::FORMAT_PLAIN)
+
+    reparsed = CFPropertyList::List.new(:data => plain, :format => CFPropertyList::List::FORMAT_PLAIN)
+    result = CFPropertyList.native_types(reparsed.value)
+
+    assert_equal original, result
+  end
 end


### PR DESCRIPTION
Fixes data corruption when round-tripping strings containing backslashes or newlines in plain format.

### Changes
- Fix backslash escaping in CFString#quoted (output `\\` instead of `\`)
- Fix newline escaping in CFString#quoted (output `\n` instead of literal newline)
- Fix regex in CFString#to_plain to use `\A\z` instead of `^$` for proper string anchoring
- Add roundtrip tests for strings with backslashes and newlines

### Background

Strings with special characters were corrupted during plain format serialization:
- Backslashes were not properly escaped, causing `"foo\bar"` to become `"foobar"`
- Newlines were output as literal characters instead of `\n`, breaking the parser
- The regex check used line anchors instead of string anchors, causing multiline strings to bypass quoting